### PR TITLE
fix: 农历日期计算与展示问题

### DIFF
--- a/src/core/hook/useYearlyCalendar.ts
+++ b/src/core/hook/useYearlyCalendar.ts
@@ -189,10 +189,12 @@ export function useYearlyCalendar(plugin: YearlyGlancePlugin) {
 					(date.getDay() === 0 || date.getDay() === 6);
 
 				// 查找当天的事件
-				const dayEvents = allEvents.filter(
-					(event) =>
-						new Date(event.dateObj).getMonth() === monthIndex &&
-						new Date(event.dateObj).getDate() === i
+				const dayEvents = allEvents.filter((event) =>
+					event.dateObj?.some((dateStr:string) =>{
+						const eventDate = new Date(dateStr);
+						return eventDate.getMonth() === monthIndex &&
+						eventDate.getDate() === i
+					})
 				);
 
 				days.push({

--- a/src/core/interfaces/Events.ts
+++ b/src/core/interfaces/Events.ts
@@ -23,7 +23,7 @@ export interface BaseEvent {
 	text: string;
 	date: string;
 	dateType: "SOLAR" | "LUNAR";
-	dateObj?: string;
+	dateObj?: string[];
 	emoji?: string;
 	color?: string;
 	remark?: string;

--- a/src/core/utils/eventCalculator.ts
+++ b/src/core/utils/eventCalculator.ts
@@ -24,7 +24,11 @@ export function calculateDateObj(
 			return [solar.toString()];
 		} else if (dateType === "LUNAR") {
 			const lunar = Lunar.fromYmd(year!, monthAbs, day);
-			return [lunar.getSolar().toString()];
+			if (lunar.getSolar().getYear() === yearSelected) {
+			    return [lunar.getSolar().toString()];
+			} else { 
+				return []
+			}
 		} else {
 			return [];
 		}

--- a/src/core/utils/eventCalculator.ts
+++ b/src/core/utils/eventCalculator.ts
@@ -1,4 +1,4 @@
-import { Lunar, Solar } from "lunar-typescript";
+import { Lunar, Solar, SolarYear } from "lunar-typescript";
 import { Birthday, CustomEvent, Holiday } from "@/src/core/interfaces/Events";
 import { isValidLunarDate, parseDateValue } from "./dateParser";
 
@@ -8,9 +8,9 @@ export function calculateDateObj(
 	dateType: "SOLAR" | "LUNAR",
 	yearSelected: number,
 	isRepeat?: boolean
-): string {
+): string[] {
 	if (!date) {
-		return "";
+		return [];
 	}
 
 	const { hasYear, year, month, day } = parseDateValue(date, dateType);
@@ -21,24 +21,32 @@ export function calculateDateObj(
 	if (isRepeat === false && hasYear) {
 		if (dateType === "SOLAR") {
 			const solar = Solar.fromYmd(year!, month, day);
-			return solar.toString();
+			return [solar.toString()];
 		} else if (dateType === "LUNAR") {
 			const lunar = Lunar.fromYmd(year!, monthAbs, day);
-			return lunar.getSolar().toString();
+			return [lunar.getSolar().toString()];
 		} else {
-			return "";
+			return [];
 		}
 	}
 
 	// 对于节日和生日，均忽略date本身的year，而使用yearSelected
 	if (dateType === "SOLAR") {
 		const solar = Solar.fromYmd(yearSelected, month, day);
-		return solar.toString();
+		return [solar.toString()];
 	} else if (dateType === "LUNAR") {
+		let lunarArr: string[] = [];
 		const lunar = Lunar.fromYmd(yearSelected, monthAbs, day);
-		return lunar.getSolar().toString();
+		const lastLunar = Lunar.fromYmd(yearSelected-1, monthAbs, day);
+		if (lunar.getSolar().getYear() === yearSelected) {
+			lunarArr.push(lunar.getSolar().toString());
+		}
+		if (lastLunar.getSolar().getYear() === yearSelected) {
+			lunarArr.push(lastLunar.getSolar().toString());
+		}
+		return lunarArr;
 	} else {
-		return "";
+		return [];
 	}
 }
 


### PR DESCRIPTION
- refactor: now dateObj is an array
- event can be show and caculate properly

fixed #14 #16 
效果（腊八节是这个情况里一个很好的示范用例）：
![PixPin_2025-04-19_06-37-28](https://github.com/user-attachments/assets/479c96fe-1ab6-4d82-84f0-7c18610f7148)

-----
另外，我认为需要将dateObj重命名为dateArr，但这可能会改变data.json，未评估影响，如果可行后续再patch