### PR TITLE
feat(yearly-calendar): 用CSS网格视图重构年历视图

### DIFF
--- a/src/components/YearlyCalendar/YearlyCalendar.tsx
+++ b/src/components/YearlyCalendar/YearlyCalendar.tsx
@@ -13,7 +13,6 @@ import {
 	layoutOptions,
 	viewTypeOptions,
 } from "@/src/components/Settings/ViewSettings";
-import { LayoutConfigMap } from "@/src/core/interfaces/Settings";
 import { useYearlyCalendar } from "@/src/core/hook/useYearlyCalendar";
 import {
 	CalendarDay,
@@ -592,32 +591,17 @@ const YearlyCalendarView: React.FC<YearlyCalendarViewProps> = ({ plugin }) => {
 			</div>
 			{/* 日历网格 */}
 			<div className={`calendar-grid layout-${layout}`}>
-				{Array.from(
-					{ length: LayoutConfigMap[layout].rows },
-					(_, row) => (
-						<div key={row} className="month-row">
-							{Array.from(
-								{ length: LayoutConfigMap[layout].cols },
-								(_, col) => {
-									const monthIndex =
-										row * LayoutConfigMap[layout].cols +
-										col;
-									return (
-										<>
-											{monthIndex < 12 && (
-												<React.Fragment
-													key={monthIndex}
-												>
-													{renderMonth(monthIndex)}
-												</React.Fragment>
-											)}
-										</>
-									);
-								}
+				{Array.from({ length: 12 }).map((_, monthIndex) => (
+						<>
+							{monthIndex < 12 && (
+								<React.Fragment
+									key={monthIndex}
+								>
+									{renderMonth(monthIndex)}
+								</React.Fragment>
 							)}
-						</div>
-					)
-				)}
+						</>
+				))}
 			</div>
 		</div>
 	);

--- a/src/components/YearlyCalendar/style/YearlyCalendarView.css
+++ b/src/components/YearlyCalendar/style/YearlyCalendarView.css
@@ -256,23 +256,14 @@
 	/* ------- 日历网格样式 ------- */
 
 	.calendar-grid {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 16px;
-		width: 100%;
-		max-width: 100%;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
 		overflow-x: hidden;
+		gap: 16px;
+		grid-auto-rows: max-content;
+		grid-row-gap: 16px;
 	}
 
-	.month-row {
-		display: flex;
-		gap: 16px;
-		flex-wrap: wrap;
-		justify-content: space-between;
-		width: 100%;
-		margin-bottom: 16px;
-		max-width: 100%;
-	}
 
 	/* ------- 月份容器样式 ------- */
 
@@ -674,12 +665,12 @@
 
 	/* 12x1 布局 */
 	.layout-12x1 .month-container {
-		flex: 1 1 100%;
+		grid: 1 1 100%;
 		max-width: 100%;
 	}
 
-	.layout-12x1 .month-row {
-		flex-wrap: wrap;
+	.layout-12x1 .cakebdar-grid {
+		grid-template-columns: repeat(12, 1fr);
 	}
 
 	/* 1x12 布局 */


### PR DESCRIPTION
将原来的固定行列的flex box改成以月历为基础单元的网格视图，以增强响应性。
已知的遗留问题是原来存在的预设布局未正确渲染，需要讨论是否删除预设布局功能或将重新修改对应逻辑


related issue #22 