### PR TITLE
fix: 修复列表视图横向滚动及布局选项显示问题

### DIFF
--- a/src/components/Settings/ViewSettings.tsx
+++ b/src/components/Settings/ViewSettings.tsx
@@ -21,11 +21,12 @@ interface ViewSettingsProps {
 }
 
 export const getLayoutOptions = (viewType: string) => {
-  const filteredLayouts = viewType === 'list' 
-    ? LAYOUT_OPTIONS 
-    : LAYOUT_OPTIONS.filter(layout => layout !== '1x12');
-    
-  return filteredLayouts.map((layout) => ({
+	// 2025-07-13 还是都加回去吧，横向滚动
+	const filteredLayouts = (viewType === 'list' || viewType === 'calendar')
+		? LAYOUT_OPTIONS
+		: LAYOUT_OPTIONS.filter(layout => layout !== '1x12');
+
+	return filteredLayouts.map((layout) => ({
     value: layout,
     label: layout,
   }));

--- a/src/components/YearlyCalendar/style/YearlyCalendarView.css
+++ b/src/components/YearlyCalendar/style/YearlyCalendarView.css
@@ -531,6 +531,7 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		text-align: start;
+		max-width: 100%;
 	}
 
 	/* ------- 列表视图样式 ------- */
@@ -724,12 +725,12 @@
 	.layout-1x12 {
 		display: flex;
 		overflow-x: auto;
-		flex-wrap: wrap;
+		flex-wrap: nowrap;
 		padding-bottom: 16px;
 		scrollbar-width: thin;
-		-webkit-overflow-scrolling: touch;
+		/* -webkit-overflow-scrolling: touch;
 		scroll-behavior: smooth;
-		scroll-snap-type: x mandatory;
+		scroll-snap-type: x mandatory; */
 	}
 
 	.layout-1x12::-webkit-scrollbar {


### PR DESCRIPTION
- YearlyCalendarView.css中调整列表视图布局，取消flex-wrap换行，
  使列表项横向滚动生效，提升用户体验
- 增加max-width限制，防止文本溢出影响布局
- ViewSettings.tsx中恢复1x12布局选项在列表和日历视图中显示，
  保证布局选择一致性和功能完整性