### PR TITLE
fix(DateInput): 支持错误信息的HTML渲染

### DIFF
--- a/src/components/Base/DateInput.tsx
+++ b/src/components/Base/DateInput.tsx
@@ -106,7 +106,11 @@ export const DateInput: React.FC<DateInputProps> = ({
 						<div className="preview-error">
 							<span className="preview-icon">⚠</span>
 							<span className="preview-text">
-								{preview.error}
+								<div
+									dangerouslySetInnerHTML={{
+										__html: preview.error,
+									}}
+								/>
 							</span>
 						</div>
 					)


### PR DESCRIPTION
将错误提示文本改为使用dangerouslySetInnerHTML渲染，
以支持包含HTML标签的错误信息显示，提升提示的灵活性和表现力。