### PR TITLE
fix: 修正事件计算器中重复事件参数类型及传递

### DIFF
--- a/src/components/YearlyCalendar/YearlyCalendar.tsx
+++ b/src/components/YearlyCalendar/YearlyCalendar.tsx
@@ -632,7 +632,6 @@ const YearlyCalendarView: React.FC<YearlyCalendarViewProps> = ({ plugin }) => {
 								>
 									<span className="legend-icon">⏩</span>
 									<span className="legend-text">
-										\
 										{t(
 											"view.yearlyGlance.actions.futureMonths"
 										)}

--- a/src/core/utils/eventCalculator.ts
+++ b/src/core/utils/eventCalculator.ts
@@ -19,7 +19,7 @@ export class EventCalculator {
 		isoDate: string,
 		calendar: CalendarType,
 		yearSelected: number,
-		isRepeat?: boolean
+		isRepeat?: boolean | undefined
 	) {
 		if (!isoDate) return [];
 

--- a/src/core/utils/eventCalculator.ts
+++ b/src/core/utils/eventCalculator.ts
@@ -27,8 +27,7 @@ export class EventCalculator {
 
 		// 自定义事件一般ymd齐全，在事件不重复，且有年份的情况下，只需要计算出公历日期
 		if (
-			isRepeat !== undefined &&
-			isRepeat === false &&
+			(isRepeat === undefined || isRepeat === false) &&
 			year !== undefined
 		) {
 			if (calendar === "GREGORIAN") {
@@ -146,7 +145,12 @@ export class EventCalculator {
 	) {
 		const isoDate = customEvent.eventDate.isoDate;
 		const calendar = customEvent.eventDate.calendar;
-		const dateArr = this.calculateDateArr(isoDate, calendar, yearSelected);
+		const dateArr = this.calculateDateArr(
+			isoDate,
+			calendar,
+			yearSelected,
+			customEvent.isRepeat
+		);
 
 		return {
 			...customEvent,


### PR DESCRIPTION
将 isRepeat 参数类型由 boolean 改为 boolean | undefined，确保类型更准确。
同时在调用 calculateDateArr 时传入 isRepeat 参数，修复重复事件计算逻辑。