### PR TITLE
feat: 优化事件提示框渲染方式及样式调整

### DIFF
--- a/src/components/YearlyCalendar/EventTooltip.tsx
+++ b/src/components/YearlyCalendar/EventTooltip.tsx
@@ -197,11 +197,13 @@ export class EventTooltip extends Modal {
 	}
 
 	onOpen() {
-		const { contentEl } = this;
-		contentEl.empty();
+		// 使用 modalEl来渲染，不加载原有的关闭按钮和标题栏
+		const { modalEl } = this;
+		modalEl.empty();
+		modalEl.addClass("yg-event-tooltip-modal");
 
 		// 创建 React 根元素
-		this.root = createRoot(contentEl);
+		this.root = createRoot(modalEl);
 
 		// 渲染包装组件
 		this.root.render(

--- a/src/components/YearlyCalendar/style/EventTooltip.css
+++ b/src/components/YearlyCalendar/style/EventTooltip.css
@@ -1,4 +1,10 @@
 /* ------- 事件提示框样式 ------- */
+/* 确保modal内容充满整个modal */
+.yg-event-tooltip-modal {
+	padding: 0;
+	border: none;
+}
+
 .yg-event-tooltip-content {
 	border-radius: 10px;
 	overflow: hidden;
@@ -77,6 +83,8 @@
 		flex-direction: column;
 		gap: 10px;
 		background-color: var(--background-primary);
+		flex: 1;
+		overflow-y: auto;
 	}
 
 	.tooltip-row {


### PR DESCRIPTION
使用 modalEl 替代 contentEl 作为渲染容器，避免加载原有关闭按钮和标题栏，
提升提示框的灵活性和样式控制。新增 yg-event-tooltip-modal 样式，确保 modal
内容充满整个容器，去除内边距和边框。同时调整内容区样式，支持纵向滚动，提升
用户体验。