### PR TITLE
feat(settings): 添加 tab 配置的 icon 字段

### DIFF
--- a/src/components/Settings/SettingsTab.tsx
+++ b/src/components/Settings/SettingsTab.tsx
@@ -12,6 +12,7 @@ export default class YearlyGlanceSettingsTab extends PluginSettingTab {
 	plugin: YearlyGlancePlugin;
 	root: Root | null = null;
 	config: YearlyGlanceConfig;
+	icon: string = "telescope";
 
 	constructor(app: App, plugin: YearlyGlancePlugin) {
 		super(app, plugin);


### PR DESCRIPTION
在 SettingsTab 类中新增了 icon 字段并初始化为 "telescope"。
该改动使得每个设置选项卡可以携带图标信息，便于在界面上
显示或定制化图标，提升配置面板的可识别性和可扩展性。